### PR TITLE
Fix "Images are displayed as block per default"

### DIFF
--- a/app/forum/static/css/naxos.css
+++ b/app/forum/static/css/naxos.css
@@ -150,6 +150,9 @@ a.category:hover {
     vertical-align:bottom;
     padding-bottom:4px;
 }
+.post-content .img-responsive {
+    display:inline-block;
+}
 /* Force some links appearance */
 a.lastMessage:link {
     color: #333333;


### PR DESCRIPTION
Fixes https://github.com/maur1th/naxos-forum/issues/69

See:
* https://dev.to/speaklouder/css-inline-vs-inline-block-vs-block-o98
* https://geekattitude.org/forum/post/1665364