### PR TITLE
Fix issue 112

### DIFF
--- a/app/forum/utils/renderer.py
+++ b/app/forum/utils/renderer.py
@@ -158,8 +158,8 @@ def rm_legacy_tags(text):
 
 class UserReferences:
 
-    # Allow any character except whitespace and BBCode-closing bracket in username
-    matching_pattern = r"(?i)(^| |\n|\])@([^\s\]]{1,30})"
+    # Match usernames: letters, digits, @/./+/-/_/& (1-150 chars)
+    matching_pattern = r"(?i)(^| |\n|\])@([\w.@+\-&]{1,150})"
     match_all = r"(^| |\n|\])@(all)"
 
     def __init__(self, text):

--- a/app/forum/utils/renderer.py
+++ b/app/forum/utils/renderer.py
@@ -158,7 +158,8 @@ def rm_legacy_tags(text):
 
 class UserReferences:
 
-    matching_pattern = r"(?i)(^| |\n|\])@((?:(?![×Þß÷þø])[-'0-9a-zÀ-ÿ_-])+)"
+    # Allow any character except whitespace and BBCode-closing bracket in username
+    matching_pattern = r"(?i)(^| |\n|\])@([^\s\]]{1,30})"
     match_all = r"(^| |\n|\])@(all)"
 
     def __init__(self, text):


### PR DESCRIPTION
Related issue: https://github.com/maur1th/naxos-forum/issues/112

This pull request updates the `matching_pattern` in the `UserReferences` class to improve username matching logic. The change ensures usernames can include a broader range of characters while maintaining restrictions on whitespace and BBCode-closing brackets.

### Update to username matching logic:

* [`app/forum/utils/renderer.py`](diffhunk://#diff-1d3f10ce50471dfb148fa6d8571605ba57976b48b25f0f63dce3dfd6b7d205b7L161-R162): Updated `matching_pattern` in the `UserReferences` class to allow any character except whitespace and BBCode-closing brackets in usernames, with a maximum length of 30 characters. This replaces the previous regex, which excluded specific characters like `×Þß÷þø`.